### PR TITLE
Add linkOnly relation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Yii2 Active Record Save Relations Behavior Change Log
 
+## [v3.1.0] Unreleased
+
+### Added
+
+- New per-relation `linkOnly` option. When set to `true`, the behavior manages only the relationship link (junction rows for a via-table relation, or the owner-side foreign key for an owner-side has-one) and never validates nor saves the related record models. Useful for linking pre-existing entities that may be invalid by their own rules. Composes with `extraColumns` and `cascadeDelete`.
+- `setRelationLinkOnly()` method to toggle link-only mode for a relation at runtime.
+
+### Notes
+
+- A `linkOnly` relation links records by primary key, so assigning an unsaved (new) record throws `yii\base\InvalidArgumentException`.
+- `linkOnly` on a relation whose foreign key is on the related record (e.g. `hasMany(Child::class, ['owner_id' => 'id'])`) throws `yii\base\InvalidConfigException`, since linking would require saving that record.
+
 ## [v3.0.0] Unreleased
 
 > This release contains breaking changes.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,44 @@ For example, related `projectLinks` records will automatically be deleted when t
 > Every records related to the main model as they are defined in their `ActiveQuery` statement will be deleted.
 
 
+Link related records without saving them (`linkOnly`)
+-----------------------------------------------------
+
+By default, assigning a relation and saving the owner validates **and** saves every related record — even pre-existing ones whose own attributes did not change. When the related records are entities you only want to *link* (not author), this is undesirable: a related record that is invalid by its own rules would make the owner save fail, and rows the user never touched would receive needless `UPDATE` statements.
+
+Declaring a relation with the `linkOnly` property set to `true` makes the behavior manage **only the relationship link** — junction rows for a via-table (many-to-many) relation, or the owner-side foreign key for an owner-side has-one. The related records are treated as immutable, pre-persisted entities referenced by primary key: they are **never validated nor saved**.
+
+```php
+...
+'saveRelations' => [
+    'class'     => SaveRelationsBehavior::class,
+    'relations' => [
+        'products' => ['linkOnly' => true],
+    ],
+],
+...
+```
+
+```php
+$category->products = [$product1, $product2]; // existing records, possibly invalid by their own rules
+$category->save();                             // syncs the junction rows only; never re-validates/re-saves the products
+```
+
+`linkOnly` composes with `extraColumns` (junction extra columns are still written on link) and with `cascadeDelete` (still honored on owner delete).
+
+> **Scope:**
+> `linkOnly` is supported for via-table (many-to-many) relations, via has-one relations, and has-one relations whose foreign key is on the owner. For a relation whose foreign key lives on the *related* record (e.g. `hasMany(Child::class, ['owner_id' => 'id'])`), linking would require saving that record, so the behavior throws a `yii\base\InvalidConfigException`.
+
+> **Note:**
+> Because a link-only relation links records by primary key, every assigned record must already be persisted. Assigning an unsaved (new) record throws a `yii\base\InvalidArgumentException`.
+
+It is also possible to toggle link-only mode at runtime using `setRelationLinkOnly`:
+
+```php
+$model->setRelationLinkOnly('relationName'); // or ->setRelationLinkOnly('relationName', false) to disable
+```
+
+
 Populate the model and its relations with input data
 ----------------------------------------------------
 This behavior adds a convenient method to load relations models attributes in the same way that the load() method does.

--- a/src/SaveRelationsBehavior.php
+++ b/src/SaveRelationsBehavior.php
@@ -43,6 +43,7 @@ class SaveRelationsBehavior extends Behavior
     private array $_relationsScenario = [];
     private array $_relationsExtraColumns = [];
     private array $_relationsCascadeDelete = [];
+    private array $_relationsLinkOnly = [];
 
     /**
      * @var bool relations attributes now honor the `safe` validation rule
@@ -56,7 +57,7 @@ class SaveRelationsBehavior extends Behavior
     public function init()
     {
         parent::init();
-        $allowedProperties = ['scenario', 'extraColumns', 'cascadeDelete'];
+        $allowedProperties = ['scenario', 'extraColumns', 'cascadeDelete', 'linkOnly'];
         foreach ($this->relations as $key => $value) {
             if (is_int($key)) {
                 $this->_relations[] = $value;
@@ -72,6 +73,43 @@ class SaveRelationsBehavior extends Behavior
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Whether the given relation is configured as link-only.
+     * A link-only relation manages only the relationship link (junction rows for a via-table
+     * relation, or the owner-side foreign key for an owner-side has-one). The related record
+     * models are treated as immutable, pre-persisted entities: they are never validated nor saved.
+     */
+    private function isLinkOnly(string $relationName): bool
+    {
+        return !empty($this->_relationsLinkOnly[$relationName]);
+    }
+
+    /**
+     * Ensure a link-only relation can actually be linked without saving the related record.
+     * That holds for via-table relations (junction rows) and for relations whose foreign key
+     * lives on the owner (the link writes the owner's own column). When the foreign key lives
+     * on the related record, linking would require saving that record, which contradicts
+     * link-only semantics, so the configuration is rejected.
+     * @throws InvalidConfigException
+     */
+    private function assertLinkOnlySupported(string $relationName, ActiveQuery $relation): void
+    {
+        if (!$this->isLinkOnly($relationName) || !empty($relation->via)) {
+            return; // via-table (M2M) / via has-one — always linkable without saving the related record
+        }
+        // Non-via: link-only is valid only when the foreign key is on the owner, i.e. the related
+        // side of the link maps to the related model's primary key (so linking writes the owner's column).
+        /** @var BaseActiveRecord $relatedClass */
+        $relatedClass = $relation->modelClass;
+        if (!$relatedClass::isPrimaryKey(array_keys($relation->link))) {
+            throw new InvalidConfigException(
+                "Relation '{$relationName}' cannot use linkOnly: its foreign key is on the related record, "
+                . 'so linking would require saving that record. Use linkOnly only for via-table (M2M) relations '
+                . 'or has-one relations whose foreign key is on the owner.'
+            );
         }
     }
 
@@ -309,6 +347,14 @@ class SaveRelationsBehavior extends Behavior
         if ($this->_relationsSaveStarted === false && $this->_oldRelationValue !== []) {
             /* @var $model BaseActiveRecord */
             $model = $this->owner;
+            // Reject unsupported link-only configurations up front, before the owner is saved.
+            // Thrown here (outside saveRelatedRecords) so InvalidConfigException propagates instead of
+            // being converted into a validation error.
+            foreach ($this->_relations as $relationName) {
+                if ($this->isLinkOnly($relationName) && array_key_exists($relationName, $this->_oldRelationValue)) {
+                    $this->assertLinkOnlySupported($relationName, $model->getRelation($relationName));
+                }
+            }
             if ($this->saveRelatedRecords($model, $event)) {
                 // If relation is has_one, try to set related model attributes
                 foreach ($this->_relations as $relationName) {
@@ -377,6 +423,18 @@ class SaveRelationsBehavior extends Behavior
     {
         Yii::debug("_prepareHasOneRelation for {$relationName}", __METHOD__);
         $relationModel = $model->{$relationName};
+        if ($this->isLinkOnly($relationName)) {
+            if ($relationModel->getIsNewRecord()) {
+                throw new InvalidArgumentException(
+                    self::prettyRelationName($relationName)
+                    . ': a linkOnly relation can only link already-persisted records (got an unsaved '
+                    . $relationModel::class . ').'
+                );
+            }
+            // Link-only: never validate nor save the related record. The owner-side foreign key is
+            // still set later by _setRelationForeignKeys(); the (existing) related row is left untouched.
+            return;
+        }
         $this->validateRelationModel(self::prettyRelationName($relationName), $relationName, $model->{$relationName});
         $relation = $model->getRelation($relationName);
         $p1 = $model->isPrimaryKey(array_keys($relation->link));
@@ -439,6 +497,20 @@ class SaveRelationsBehavior extends Behavior
      */
     private function _prepareHasManyRelation(BaseActiveRecord $model, $relationName)
     {
+        if ($this->isLinkOnly($relationName)) {
+            // Link-only: never validate the related records; only the junction rows are synced in afterSave.
+            /** @var BaseActiveRecord $relationModel */
+            foreach ($model->{$relationName} as $i => $relationModel) {
+                if ($relationModel->getIsNewRecord()) {
+                    throw new InvalidArgumentException(
+                        self::prettyRelationName($relationName, $i)
+                        . ': a linkOnly relation can only link already-persisted records (got an unsaved '
+                        . $relationModel::class . ').'
+                    );
+                }
+            }
+            return;
+        }
         /** @var BaseActiveRecord $relationModel */
         foreach ($model->{$relationName} as $i => $relationModel) {
             $this->validateRelationModel(self::prettyRelationName($relationName, $i), $relationName, $relationModel);
@@ -538,8 +610,17 @@ class SaveRelationsBehavior extends Behavior
         // Process new relations
         $existingRecords = [];
         /** @var ActiveQuery $relationModel */
+        $linkOnly = $this->isLinkOnly($relationName);
         foreach ($owner->{$relationName} as $i => $relationModel) {
             if ($relationModel->isNewRecord) {
+                if ($linkOnly) {
+                    // Reached only via save(false) (validation skipped); link-only cannot link an unsaved record.
+                    throw new InvalidArgumentException(
+                        self::prettyRelationName($relationName, $i)
+                        . ': a linkOnly relation can only link already-persisted records (got an unsaved '
+                        . $relationModel::class . ').'
+                    );
+                }
                 if (!empty($relation->via) && !$relationModel->save()) {
                     $this->_addError($relationModel, $owner, $relationName, self::prettyRelationName($relationName, $i));
                     throw new DbException('Related record ' . self::prettyRelationName($relationName, $i) . ' could not be saved.');
@@ -549,7 +630,8 @@ class SaveRelationsBehavior extends Behavior
             } else {
                 $existingRecords[] = $relationModel;
             }
-            if ((count($relationModel->dirtyAttributes) || count($this->_newRelationValue)) && !$relationModel->save()) {
+            // Link-only: never save the related record; only the junction rows (synced below) are touched.
+            if (!$linkOnly && (count($relationModel->dirtyAttributes) || count($this->_newRelationValue)) && !$relationModel->save()) {
                 $this->_addError($relationModel, $owner, $relationName, self::prettyRelationName($relationName));
                 throw new DbException('Related record ' . self::prettyRelationName($relationName) . ' could not be saved.');
             }
@@ -646,7 +728,8 @@ class SaveRelationsBehavior extends Behavior
                 $owner->unlink($relationName, $this->_oldRelationValue[$relationName]);
             }
         }
-        if ($owner->{$relationName} instanceof BaseActiveRecord) {
+        // Link-only: the link (owner FK) is written above, but the related record is never saved.
+        if (!$this->isLinkOnly($relationName) && $owner->{$relationName} instanceof BaseActiveRecord) {
             $owner->{$relationName}->save();
         }
     }
@@ -732,6 +815,25 @@ class SaveRelationsBehavior extends Behavior
             throw new InvalidArgumentException('Unknown ' . $relationName . ' relation');
         }
 
+    }
+
+    /**
+     * Toggle link-only mode for a given relation at runtime.
+     * @see isLinkOnly()
+     * @param string $relationName
+     * @param bool $linkOnly
+     * @throws InvalidArgumentException
+     */
+    public function setRelationLinkOnly($relationName, $linkOnly = true)
+    {
+        /** @var BaseActiveRecord $owner */
+        $owner = $this->owner;
+        $relation = $owner->getRelation($relationName, false);
+        if (in_array($relationName, $this->_relations) && !is_null($relation)) {
+            $this->_relationsLinkOnly[$relationName] = $linkOnly;
+        } else {
+            throw new InvalidArgumentException('Unknown ' . $relationName . ' relation');
+        }
     }
 
     /**

--- a/tests/LinkOnlyTest.php
+++ b/tests/LinkOnlyTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace tests;
+
+use PHPUnit\Framework\TestCase;
+use tests\models\LinkOnlyChild;
+use tests\models\LinkOnlyOwner;
+use tests\models\LinkOnlyProduct;
+use Yii;
+use yii\base\InvalidArgumentException;
+use yii\base\InvalidConfigException;
+use yii\db\Exception as DbException;
+use yii\db\Query;
+
+/**
+ * Tests for the per-relation `linkOnly` option: the behavior manages only the relationship
+ * link (junction rows for a via-table relation, the owner-side foreign key for an owner-side
+ * has-one) and never validates nor saves the related record models.
+ */
+class LinkOnlyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupDb();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = Yii::$app->getDb();
+        foreach (['lo_owner_product', 'lo_child', 'lo_owner', 'lo_product'] as $table) {
+            $db->createCommand('DROP TABLE IF EXISTS ' . $db->quoteTableName($table))->execute();
+        }
+        parent::tearDown();
+    }
+
+    private function setupDb(): void
+    {
+        $db = Yii::$app->getDb();
+        foreach (['lo_owner_product', 'lo_child', 'lo_owner', 'lo_product'] as $table) {
+            $db->createCommand('DROP TABLE IF EXISTS ' . $db->quoteTableName($table))->execute();
+        }
+
+        // `code` is nullable in the schema but required by the model rules: seeded rows are
+        // valid as data but fail validate(), the exact situation linkOnly must tolerate.
+        $db->createCommand()->createTable('lo_product', [
+            'id'   => 'pk',
+            'code' => 'string NULL',
+        ])->execute();
+        $db->createCommand()->createTable('lo_owner', [
+            'id'              => 'pk',
+            'name'            => 'string NOT NULL',
+            'main_product_id' => 'integer NULL',
+        ])->execute();
+        $db->createCommand()->createTable('lo_child', [
+            'id'       => 'pk',
+            'owner_id' => 'integer NOT NULL',
+        ])->execute();
+        $db->createCommand()->createTable('lo_owner_product', [
+            'owner_id'   => 'integer NOT NULL',
+            'product_id' => 'integer NOT NULL',
+            'sort_order' => 'integer NULL',
+            'PRIMARY KEY(owner_id, product_id)',
+        ])->execute();
+
+        $db->createCommand()->batchInsert('lo_product', ['id', 'code'], [
+            [1, null],          // exists but invalid (code blank)
+            [2, null],          // exists but invalid (code blank)
+            [3, 'valid-code'],
+        ])->execute();
+        $db->createCommand()->batchInsert('lo_owner', ['id', 'name', 'main_product_id'], [
+            [1, 'Owner One', null],
+        ])->execute();
+        $db->createCommand()->batchInsert('lo_child', ['id', 'owner_id'], [
+            [1, 1],
+        ])->execute();
+    }
+
+    /** @return int[] product ids currently linked to the owner via the junction table */
+    private function linkedProductIds(int $ownerId): array
+    {
+        $ids = new Query()
+            ->select('product_id')
+            ->from('lo_owner_product')
+            ->where(['owner_id' => $ownerId])
+            ->column(Yii::$app->getDb());
+        $ids = array_map(intval(...), $ids);
+        sort($ids);
+        return $ids;
+    }
+
+    public function testLinkOnlyHasManyLinksWithoutValidatingOrSavingRelated()
+    {
+        $owner = LinkOnlyOwner::findOne(1);
+
+        $product1 = LinkOnlyProduct::findOne(1); // code is null -> invalid
+        $product1->code = 'in-memory-change';    // dirty; must NOT be persisted
+        $product2 = LinkOnlyProduct::findOne(2);
+
+        $owner->products = [$product1, $product2];
+
+        $this->assertTrue($owner->save(), 'Owner with a linkOnly relation should save despite invalid related records');
+        $this->assertSame([], $owner->getErrors(), 'No related-side errors should bubble onto the owner');
+        $this->assertSame([1, 2], $this->linkedProductIds(1), 'Junction rows should match the assigned set');
+
+        $reloaded = LinkOnlyProduct::findOne(1);
+        $this->assertNull($reloaded->code, 'The related record must not be saved (the in-memory change must not persist)');
+    }
+
+    public function testLinkOnlyHasManyAddAndRemoveLinks()
+    {
+        Yii::$app->getDb()->createCommand()
+            ->insert('lo_owner_product', ['owner_id' => 1, 'product_id' => 1])
+            ->execute();
+
+        $owner = LinkOnlyOwner::findOne(1);
+        $owner->products = [2, 3]; // drop 1, add 2 and 3
+
+        $this->assertTrue($owner->save());
+        $this->assertSame([2, 3], $this->linkedProductIds(1), 'Junction should reflect exactly the new set');
+        $this->assertNotNull(LinkOnlyProduct::findOne(1), 'A dropped record must only be unlinked, never deleted');
+    }
+
+    public function testLinkOnlyComposesWithExtraColumns()
+    {
+        $product = LinkOnlyProduct::findOne(2);
+        $product->sortOrder = 7;
+        $owner = LinkOnlyOwner::findOne(1);
+        $owner->products = [$product];
+
+        $this->assertTrue($owner->save());
+
+        $sortOrder = new Query()
+            ->select('sort_order')
+            ->from('lo_owner_product')
+            ->where(['owner_id' => 1, 'product_id' => 2])
+            ->scalar(Yii::$app->getDb());
+        $this->assertEquals(7, $sortOrder, 'extraColumns values should be written to the junction row');
+    }
+
+    public function testLinkOnlyHasManyRejectsUnsavedRecord()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $owner = LinkOnlyOwner::findOne(1);
+        $owner->products = [new LinkOnlyProduct(['code' => 'brand-new'])];
+        $owner->save();
+    }
+
+    public function testNonLinkOnlyStillValidatesAndSavesRelated()
+    {
+        // Control: the same invalid existing record assigned to a NON-linkOnly relation makes the
+        // owner save fail (the behavior re-saves the related record, which fails validation).
+        $this->expectException(DbException::class);
+
+        $owner = LinkOnlyOwner::findOne(1);
+        $owner->productsStrict = [LinkOnlyProduct::findOne(1)]; // code is null -> invalid
+        $owner->save();
+    }
+
+    public function testLinkOnlyHasOneWithOwnerSideForeignKey()
+    {
+        $owner = LinkOnlyOwner::findOne(1);
+        $product = LinkOnlyProduct::findOne(1); // code is null -> invalid
+        $product->code = 'in-memory-change';    // dirty; must NOT be persisted
+
+        $owner->mainProduct = $product;
+
+        $this->assertTrue($owner->save(), 'linkOnly has-one should link an invalid existing record');
+        $this->assertSame([], $owner->getErrors());
+        $this->assertEquals(1, $owner->main_product_id, "Owner's foreign key should point at the linked record");
+
+        $reloaded = LinkOnlyProduct::findOne(1);
+        $this->assertNull($reloaded->code, 'The related has-one record must not be saved');
+    }
+
+    public function testLinkOnlyRejectsForeignKeyOnRelatedRecord()
+    {
+        // `children` is a has-many whose foreign key lives on the related row: linking would
+        // require saving the child, which contradicts linkOnly, so it must be rejected.
+        $this->expectException(InvalidConfigException::class);
+
+        $owner = LinkOnlyOwner::findOne(1);
+        $owner->children = [LinkOnlyChild::findOne(1)];
+        $owner->save();
+    }
+}

--- a/tests/models/LinkOnlyChild.php
+++ b/tests/models/LinkOnlyChild.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace tests\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * Child whose foreign key (`owner_id`) lives on its own table. A linkOnly relation pointing
+ * here cannot be linked without saving the child, so the behavior must reject the configuration.
+ */
+class LinkOnlyChild extends ActiveRecord
+{
+    #[\Override]
+    public static function tableName()
+    {
+        return 'lo_child';
+    }
+}

--- a/tests/models/LinkOnlyOwner.php
+++ b/tests/models/LinkOnlyOwner.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace tests\models;
+
+use p4it\saveRelationsBehavior\SaveRelationsBehavior;
+use yii\db\ActiveRecord;
+
+/**
+ * Owner exercising the linkOnly option across relation types:
+ *  - products       : has-many via-table (M2M), linkOnly + extraColumns
+ *  - productsStrict  : same junction WITHOUT linkOnly (control for the regression test)
+ *  - mainProduct     : has-one whose foreign key is on the owner, linkOnly
+ *  - children        : has-many whose foreign key is on the related record — unsupported for linkOnly
+ */
+class LinkOnlyOwner extends ActiveRecord
+{
+    #[\Override]
+    public static function tableName()
+    {
+        return 'lo_owner';
+    }
+
+    #[\Override]
+    public function behaviors()
+    {
+        return [
+            'saveRelations' => [
+                'class'     => SaveRelationsBehavior::class,
+                'relations' => [
+                    'products'       => [
+                        'linkOnly'     => true,
+                        'extraColumns' => fn (LinkOnlyProduct $model) => ['sort_order' => $model->sortOrder],
+                    ],
+                    'productsStrict' => [],
+                    'mainProduct'    => ['linkOnly' => true],
+                    'children'       => ['linkOnly' => true],
+                ],
+            ],
+        ];
+    }
+
+    #[\Override]
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['main_product_id'], 'integer'],
+            [['products', 'productsStrict', 'mainProduct', 'children'], 'safe'],
+        ];
+    }
+
+    public function getProducts()
+    {
+        return $this->hasMany(LinkOnlyProduct::class, ['id' => 'product_id'])
+            ->viaTable('lo_owner_product', ['owner_id' => 'id']);
+    }
+
+    public function getProductsStrict()
+    {
+        return $this->hasMany(LinkOnlyProduct::class, ['id' => 'product_id'])
+            ->viaTable('lo_owner_product', ['owner_id' => 'id']);
+    }
+
+    public function getMainProduct()
+    {
+        return $this->hasOne(LinkOnlyProduct::class, ['id' => 'main_product_id']);
+    }
+
+    public function getChildren()
+    {
+        return $this->hasMany(LinkOnlyChild::class, ['owner_id' => 'id']);
+    }
+}

--- a/tests/models/LinkOnlyProduct.php
+++ b/tests/models/LinkOnlyProduct.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace tests\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * A related record used by the linkOnly tests. Its `code` is required by its own rules,
+ * but the seeded rows leave it blank — so the record exists (has a primary key) yet fails
+ * validate(). A linkOnly relation must be able to link such a record without validating
+ * or saving it.
+ */
+class LinkOnlyProduct extends ActiveRecord
+{
+    /** @var int|null transient value written to the junction table through extraColumns */
+    public $sortOrder;
+
+    #[\Override]
+    public static function tableName()
+    {
+        return 'lo_product';
+    }
+
+    #[\Override]
+    public function rules()
+    {
+        return [
+            [['code'], 'required'],
+            [['code'], 'string'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Adds a per-relation **`linkOnly`** boolean option (default `false`, so existing behavior is unchanged). When `true`, the behavior manages **only the relationship link** — junction rows for a via-table (M2M) relation, or the owner-side foreign key for an owner-side has-one — and **never validates nor saves** the related record models.

This solves the case where you assign a relation of pre-existing entities you only want to *link* (not author): related records that are invalid by their own rules no longer make the owner save fail, and rows the user never touched no longer receive needless `UPDATE`s.

```php
'saveRelations' => [
    'class'     => SaveRelationsBehavior::class,
    'relations' => ['products' => ['linkOnly' => true]],
],
```

## Behavior
- **Composes** with `extraColumns` (junction columns still written on link) and `cascadeDelete` (still honored on owner delete).
- Assigning an **unsaved (new)** record → `yii\base\InvalidArgumentException` (link-only links by primary key).
- `linkOnly` on a relation whose **FK is on the related record** (e.g. `hasMany(Child::class, ['owner_id' => 'id'])`) → `yii\base\InvalidConfigException`. This is asserted in `beforeValidate`, so it propagates and fails **before the owner is saved** (rather than being swallowed into a validation error or thrown after the owner row is committed).
- New `setRelationLinkOnly()` for runtime toggling, mirroring `setRelationScenario()`.

## Implementation notes
- `_prepareHasOneRelation()` / `_prepareHasManyRelation()`: skip validation for link-only relations; guard against unsaved records up front (the has-one guard is required because `_setRelationForeignKeys()` would otherwise still save a new has-one record).
- `_afterSaveHasManyRelation()` / `_afterSaveHasOneRelation()`: skip the related-record `save()` for link-only relations; keep the junction link/unlink and owner-FK write intact.

## Tests
New self-contained `tests/LinkOnlyTest.php` (+ `LinkOnly*` fixtures), covering: M2M happy path (links an invalid existing record, proves the related row is not saved), add/remove links, `extraColumns` composition, new-record guard, owner-side-FK has-one, the unsupported-combination guard, and a **non-linkOnly control** that demonstrates the original failure.

- `vendor/bin/phpunit` → **57 tests, 224 assertions, OK** (50 existing + 7 new)
- `vendor/bin/rector process --dry-run` → clean
- `vendor/bin/php-cs-fixer fix --dry-run` → clean

README and CHANGELOG (v3.1.0) updated.

> Note: targets `master`. The v3.0.0 modernization (PHP 8.4 / PHPUnit 12 / Rector / CS-Fixer) is already merged, so this is a backward-compatible **minor** bump (v3.1.0), not the 2.1.0 the original spec assumed.