### PR TITLE
Add sortColumn relation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Yii2 Active Record Save Relations Behavior Change Log
 
+## [v3.2.0] - 2026-06-09
+
+### Added
+
+- New per-relation `sortColumn` option. When set to a junction-table column name, the behavior persists the 0-based position of each related record — in submitted order — into that column on every save, for via-table (many-to-many) relations. All positions are rewritten on each save, so a pure reorder (no membership change) is persisted too. Composes with `linkOnly` and `extraColumns` (the latter scopes which rows a relation renumbers when a junction is shared across relations).
+
+### Notes
+
+- `sortColumn` is supported only for via-table relations declared with `viaTable()`; configuring it on any other relation throws `yii\base\InvalidConfigException`.
+
 ## [v3.1.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -290,6 +290,40 @@ $model->setRelationLinkOnly('relationName'); // or ->setRelationLinkOnly('relati
 ```
 
 
+Persist the submitted order of a many-to-many relation (`sortColumn`)
+---------------------------------------------------------------------
+
+A junction table is an unordered set: by default the order in which related records are submitted is not stored anywhere, and re-saving the same records in a different order leaves the junction rows untouched. Declaring a relation with the `sortColumn` property makes the behavior write the **0-based position of each related record, in submitted order**, into the named junction-table column on every save.
+
+```php
+...
+'saveRelations' => [
+    'class'     => SaveRelationsBehavior::class,
+    'relations' => [
+        'products'     => ['linkOnly' => true, 'sortColumn' => 'sort_order'],
+        // sharing a junction across types: extraColumns scopes which rows are renumbered
+        'galleryFiles' => ['extraColumns' => ['type' => MediaFile::TYPE_GALLERY], 'sortColumn' => 'sort_order'],
+    ],
+],
+...
+```
+
+```php
+$category->products = [$product3, $product1, $product2];
+$category->save(); // junction sort_order becomes 0, 1, 2 for product3, product1, product2
+```
+
+All positions are rewritten on every save, so a pure reorder (no record added or removed) is persisted too — something `$owner->link()` alone cannot do, since it only ever touches added rows. The behavior owns **only this write**; how the relation reads back ordered stays in the relation getter (e.g. an `ORDER BY sort_order` in `getProducts()`).
+
+`sortColumn` composes with `linkOnly` and with `extraColumns`. When `extraColumns` is set (e.g. a `type` discriminator), it scopes the rows a relation renumbers, so several relations can share one junction without clobbering each other's order.
+
+> **Scope:**
+> `sortColumn` is supported only for via-table (many-to-many) relations declared with `viaTable()`. Configuring it on any other relation throws a `yii\base\InvalidConfigException`.
+
+> **Note:**
+> For a junction shared by several relations distinguished by an `extraColumns` discriminator, encode that discriminator in the relation's `onCondition` too (e.g. `->viaTable('table', $link, fn ($q) => $q->andOnCondition(['type' => ...]))`), so that reading and unlinking stay scoped to the right rows.
+
+
 Populate the model and its relations with input data
 ----------------------------------------------------
 This behavior adds a convenient method to load relations models attributes in the same way that the load() method does.

--- a/src/SaveRelationsBehavior.php
+++ b/src/SaveRelationsBehavior.php
@@ -44,6 +44,7 @@ class SaveRelationsBehavior extends Behavior
     private array $_relationsExtraColumns = [];
     private array $_relationsCascadeDelete = [];
     private array $_relationsLinkOnly = [];
+    private array $_relationsSortColumn = [];
 
     /**
      * @var bool relations attributes now honor the `safe` validation rule
@@ -57,7 +58,7 @@ class SaveRelationsBehavior extends Behavior
     public function init()
     {
         parent::init();
-        $allowedProperties = ['scenario', 'extraColumns', 'cascadeDelete', 'linkOnly'];
+        $allowedProperties = ['scenario', 'extraColumns', 'cascadeDelete', 'linkOnly', 'sortColumn'];
         foreach ($this->relations as $key => $value) {
             if (is_int($key)) {
                 $this->_relations[] = $value;
@@ -88,6 +89,14 @@ class SaveRelationsBehavior extends Behavior
     }
 
     /**
+     * Whether the given relation persists its submitted order into a junction column (`sortColumn`).
+     */
+    private function isSortColumn(string $relationName): bool
+    {
+        return isset($this->_relationsSortColumn[$relationName]);
+    }
+
+    /**
      * Ensure a link-only relation can actually be linked without saving the related record.
      * That holds for via-table relations (junction rows) and for relations whose foreign key
      * lives on the owner (the link writes the owner's own column). When the foreign key lives
@@ -109,6 +118,27 @@ class SaveRelationsBehavior extends Behavior
                 "Relation '{$relationName}' cannot use linkOnly: its foreign key is on the related record, "
                 . 'so linking would require saving that record. Use linkOnly only for via-table (M2M) relations '
                 . 'or has-one relations whose foreign key is on the owner.'
+            );
+        }
+    }
+
+    /**
+     * Ensure a `sortColumn` relation actually has a junction table to write the position to.
+     * sortColumn persists the submitted order into a junction-table column, so it is only meaningful
+     * for via-table (M2M) relations; configuring it elsewhere is rejected. Checked up front (before
+     * the owner is saved) so the InvalidConfigException propagates instead of failing mid-transaction.
+     * @throws InvalidConfigException
+     */
+    private function assertSortColumnSupported(string $relationName, ActiveQuery $relation): void
+    {
+        if (!$this->isSortColumn($relationName)) {
+            return;
+        }
+        $via = $relation->via;
+        if (!$via instanceof ActiveQuery || empty($via->from)) {
+            throw new InvalidConfigException(
+                "Relation '{$relationName}' uses sortColumn but is not a via-table (M2M) relation; "
+                . 'sortColumn writes a position to a junction table, so define the relation with viaTable().'
             );
         }
     }
@@ -351,9 +381,12 @@ class SaveRelationsBehavior extends Behavior
             // Thrown here (outside saveRelatedRecords) so InvalidConfigException propagates instead of
             // being converted into a validation error.
             foreach ($this->_relations as $relationName) {
-                if ($this->isLinkOnly($relationName) && array_key_exists($relationName, $this->_oldRelationValue)) {
-                    $this->assertLinkOnlySupported($relationName, $model->getRelation($relationName));
+                if (!array_key_exists($relationName, $this->_oldRelationValue)) {
+                    continue;
                 }
+                $relation = $model->getRelation($relationName);
+                $this->assertLinkOnlySupported($relationName, $relation); // no-op unless linkOnly
+                $this->assertSortColumnSupported($relationName, $relation); // no-op unless sortColumn
             }
             if ($this->saveRelatedRecords($model, $event)) {
                 // If relation is has_one, try to set related model attributes
@@ -607,6 +640,11 @@ class SaveRelationsBehavior extends Behavior
         /** @var ActiveQuery $relation */
         $relation = $owner->getRelation($relationName);
 
+        // Snapshot the submitted order BEFORE link()/unlink() mutate the populated relation below:
+        // link() appends to the in-memory set (see BaseActiveRecord::link()), so reading the relation
+        // after the sync would double-count added rows. sortColumn needs the order exactly as submitted.
+        $sortedModels = $this->isSortColumn($relationName) ? $owner->{$relationName} : [];
+
         // Process new relations
         $existingRecords = [];
         /** @var ActiveQuery $relationModel */
@@ -660,6 +698,57 @@ class SaveRelationsBehavior extends Behavior
         foreach ($addedPks as $key) {
             $junctionTableColumns = $this->_getJunctionTableColumns($relationName, $actualModels[$key]);
             $owner->link($relationName, $actualModels[$key], $junctionTableColumns);
+        }
+
+        $this->_applyRelationSortColumn($relationName, $relation, $sortedModels);
+    }
+
+    /**
+     * Persist the submitted order of a via-table (M2M) relation into a sort column on the junction
+     * table (configured per relation via the `sortColumn` option). Positions are 0-based, in
+     * submitted order. Must run after the junction rows are linked and before the owner is refreshed.
+     *
+     * Each junction row is matched by owner key + related key + the relation's extraColumns (e.g. a
+     * `type` discriminator), so a junction shared by several relations is scoped correctly. The two
+     * link loops (rather than array_key_first) keep it correct for composite-key junctions too.
+     *
+     * @param BaseActiveRecord[] $orderedModels related models in submitted order, captured before
+     *                                          link()/unlink() mutated the populated relation
+     * @throws InvalidConfigException when sortColumn is set on a non-via-table relation
+     * @throws DbException
+     */
+    private function _applyRelationSortColumn(string $relationName, ActiveQuery $relation, array $orderedModels): void
+    {
+        if (!$this->isSortColumn($relationName)) {
+            return;
+        }
+
+        $via = $relation->via;
+        // Validated up front in beforeValidate(); re-checked defensively (e.g. markRelationDirty()).
+        if (!$via instanceof ActiveQuery || empty($via->from)) {
+            throw new InvalidConfigException(
+                "Relation '{$relationName}' uses sortColumn but is not a via-table (M2M) relation; "
+                . 'sortColumn writes a position to a junction table, so define the relation with viaTable().'
+            );
+        }
+
+        /** @var BaseActiveRecord $owner */
+        $owner = $this->owner;
+        $sortColumn = $this->_relationsSortColumn[$relationName];
+        $junctionTable = reset($via->from);
+        $db = $owner->getDb();
+
+        $position = 0;
+        foreach ($orderedModels as $relationModel) {
+            $condition = $this->_getJunctionTableColumns($relationName, $relationModel);
+            foreach ($via->link as $junctionColumn => $ownerAttribute) {
+                $condition[$junctionColumn] = $owner->{$ownerAttribute};
+            }
+            foreach ($relation->link as $relatedAttribute => $junctionColumn) {
+                $condition[$junctionColumn] = $relationModel->{$relatedAttribute};
+            }
+
+            $db->createCommand()->update($junctionTable, [$sortColumn => $position++], $condition)->execute();
         }
     }
 

--- a/tests/SortColumnTest.php
+++ b/tests/SortColumnTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace tests;
+
+use PHPUnit\Framework\TestCase;
+use tests\models\SortChild;
+use tests\models\SortItem;
+use tests\models\SortOwner;
+use Yii;
+use yii\base\InvalidConfigException;
+use yii\db\Query;
+
+/**
+ * Tests for the per-relation `sortColumn` option: the behavior persists the submitted order of a
+ * via-table (M2M) relation into a column on the junction table, as 0-based positions.
+ *
+ * Assertions read the junction `sort_order` column directly (never the reloaded relation order),
+ * because the positions are what the feature owns — the read ordering stays in the relation getter.
+ */
+class SortColumnTest extends TestCase
+{
+    private const array TABLES = ['sort_owner_gallery', 'sort_owner_item', 'sort_child', 'sort_item', 'sort_owner'];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupDb();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = Yii::$app->getDb();
+        foreach (self::TABLES as $table) {
+            $db->createCommand('DROP TABLE IF EXISTS ' . $db->quoteTableName($table))->execute();
+        }
+        parent::tearDown();
+    }
+
+    private function setupDb(): void
+    {
+        $db = Yii::$app->getDb();
+        foreach (self::TABLES as $table) {
+            $db->createCommand('DROP TABLE IF EXISTS ' . $db->quoteTableName($table))->execute();
+        }
+
+        $db->createCommand()->createTable('sort_owner', [
+            'id'   => 'pk',
+            'name' => 'string NOT NULL',
+        ])->execute();
+        $db->createCommand()->createTable('sort_item', [
+            'id'   => 'pk',
+            'name' => 'string NULL',
+        ])->execute();
+        $db->createCommand()->createTable('sort_child', [
+            'id'       => 'pk',
+            'owner_id' => 'integer NOT NULL',
+        ])->execute();
+        // Plain M2M junction (items / linkedItems).
+        $db->createCommand()->createTable('sort_owner_item', [
+            'owner_id'   => 'integer NOT NULL',
+            'item_id'    => 'integer NOT NULL',
+            'sort_order' => 'integer NULL',
+            'PRIMARY KEY(owner_id, item_id)',
+        ])->execute();
+        // Junction shared by galleryItems and docItems, distinguished by `type`.
+        $db->createCommand()->createTable('sort_owner_gallery', [
+            'owner_id'   => 'integer NOT NULL',
+            'item_id'    => 'integer NOT NULL',
+            'type'       => 'string NOT NULL',
+            'sort_order' => 'integer NULL',
+            'PRIMARY KEY(owner_id, item_id, type)',
+        ])->execute();
+
+        $db->createCommand()->batchInsert('sort_owner', ['id', 'name'], [[1, 'Owner One']])->execute();
+        $db->createCommand()->batchInsert('sort_item', ['id', 'name'], [
+            [1, 'i1'], [2, 'i2'], [3, 'i3'], [4, 'i4'],
+            [10, 'i10'], [11, 'i11'], [12, 'i12'], [20, 'i20'],
+        ])->execute();
+        $db->createCommand()->batchInsert('sort_child', ['id', 'owner_id'], [[1, 1]])->execute();
+    }
+
+    /**
+     * @return array<int,int|null> map of item_id => sort_order for the matching junction rows
+     */
+    private function positions(string $table, array $where): array
+    {
+        $rows = new Query()
+            ->select(['item_id', 'sort_order'])
+            ->from($table)
+            ->where($where)
+            ->all(Yii::$app->getDb());
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(int) $row['item_id']] = $row['sort_order'] === null ? null : (int) $row['sort_order'];
+        }
+        return $map;
+    }
+
+    private function seedJunction(string $table, array $rows): void
+    {
+        $db = Yii::$app->getDb();
+        foreach ($rows as $row) {
+            $db->createCommand()->insert($table, $row)->execute();
+        }
+    }
+
+    public function testInsertWritesContiguousZeroBasedPositions(): void
+    {
+        $owner = SortOwner::findOne(1);
+        $owner->items = [SortItem::findOne(3), SortItem::findOne(1), SortItem::findOne(2)];
+
+        $this->assertTrue($owner->save(), 'Owner should save');
+        $this->assertEquals(
+            [3 => 0, 1 => 1, 2 => 2],
+            $this->positions('sort_owner_item', ['owner_id' => 1]),
+            'Junction sort_order must be 0..N-1 in submitted order'
+        );
+    }
+
+    public function testReorderWithoutMembershipChangeUpdatesPositions(): void
+    {
+        $this->seedJunction('sort_owner_item', [
+            ['owner_id' => 1, 'item_id' => 1, 'sort_order' => 0],
+            ['owner_id' => 1, 'item_id' => 2, 'sort_order' => 1],
+            ['owner_id' => 1, 'item_id' => 3, 'sort_order' => 2],
+        ]);
+
+        $owner = SortOwner::findOne(1);
+        $owner->items = [SortItem::findOne(2), SortItem::findOne(3), SortItem::findOne(1)]; // pure reorder
+
+        $this->assertTrue($owner->save());
+        $this->assertEquals(
+            [2 => 0, 3 => 1, 1 => 2],
+            $this->positions('sort_owner_item', ['owner_id' => 1]),
+            'A pure reorder (no membership change) must still rewrite positions'
+        );
+    }
+
+    public function testAddRemoveReorderRenumbersContiguously(): void
+    {
+        $this->seedJunction('sort_owner_item', [
+            ['owner_id' => 1, 'item_id' => 1, 'sort_order' => 0],
+            ['owner_id' => 1, 'item_id' => 2, 'sort_order' => 1],
+            ['owner_id' => 1, 'item_id' => 3, 'sort_order' => 2],
+        ]);
+
+        $owner = SortOwner::findOne(1);
+        // Drop 2, add 4, reorder: submitted order [3, 4, 1].
+        $owner->items = [SortItem::findOne(3), SortItem::findOne(4), SortItem::findOne(1)];
+
+        $this->assertTrue($owner->save());
+        $this->assertEquals(
+            [3 => 0, 4 => 1, 1 => 2],
+            $this->positions('sort_owner_item', ['owner_id' => 1]),
+            'Surviving + added rows must be renumbered contiguously in submitted order'
+        );
+    }
+
+    public function testExtraColumnsDiscriminatorScopesPositionsAndLeavesOtherTypeUntouched(): void
+    {
+        $this->seedJunction('sort_owner_gallery', [
+            ['owner_id' => 1, 'item_id' => 10, 'type' => 'gallery', 'sort_order' => 0],
+            ['owner_id' => 1, 'item_id' => 11, 'type' => 'gallery', 'sort_order' => 1],
+            // Same items under a different type — must be left completely untouched.
+            ['owner_id' => 1, 'item_id' => 10, 'type' => 'doc', 'sort_order' => 7],
+            ['owner_id' => 1, 'item_id' => 11, 'type' => 'doc', 'sort_order' => 8],
+        ]);
+
+        $owner = SortOwner::findOne(1);
+        // gallery: drop 11, add 12, reorder -> [12, 10].
+        $owner->galleryItems = [SortItem::findOne(12), SortItem::findOne(10)];
+
+        $this->assertTrue($owner->save());
+        $this->assertEquals(
+            [12 => 0, 10 => 1],
+            $this->positions('sort_owner_gallery', ['owner_id' => 1, 'type' => 'gallery']),
+            'Only the gallery rows should be renumbered, in submitted order'
+        );
+        $this->assertEquals(
+            [10 => 7, 11 => 8],
+            $this->positions('sort_owner_gallery', ['owner_id' => 1, 'type' => 'doc']),
+            'Rows of the other relation sharing the junction must be untouched'
+        );
+    }
+
+    public function testLinkOnlyComposesWithSortColumn(): void
+    {
+        $dirty = SortItem::findOne(3);
+        $dirty->name = 'changed-in-memory'; // must NOT be persisted by a linkOnly relation
+
+        $owner = SortOwner::findOne(1);
+        $owner->linkedItems = [$dirty, SortItem::findOne(1), SortItem::findOne(2)];
+
+        $this->assertTrue($owner->save());
+        $this->assertEquals(
+            [3 => 0, 1 => 1, 2 => 2],
+            $this->positions('sort_owner_item', ['owner_id' => 1]),
+            'linkOnly + sortColumn must still persist positions'
+        );
+        $this->assertSame(
+            'i3',
+            SortItem::findOne(3)->name,
+            'A linkOnly related record must never be saved'
+        );
+    }
+
+    public function testSortColumnOnNonViaRelationThrows(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+
+        $owner = SortOwner::findOne(1);
+        $owner->children = [SortChild::findOne(1)]; // non-via has-many: no junction to write a position to
+        $owner->save();
+    }
+}

--- a/tests/models/SortChild.php
+++ b/tests/models/SortChild.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace tests\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * Child whose foreign key (`owner_id`) lives on its own table, i.e. a non-via has-many relation.
+ * Configuring `sortColumn` on such a relation is unsupported (there is no junction table to write
+ * a position to), so the behavior must reject it with an InvalidConfigException.
+ */
+class SortChild extends ActiveRecord
+{
+    #[\Override]
+    public static function tableName()
+    {
+        return 'sort_child';
+    }
+}

--- a/tests/models/SortItem.php
+++ b/tests/models/SortItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace tests\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * A related record used by the sortColumn tests. It is a plain, valid entity whose only job is
+ * to be linked to a {@see SortOwner} through a via-table relation that persists submitted order.
+ */
+class SortItem extends ActiveRecord
+{
+    #[\Override]
+    public static function tableName()
+    {
+        return 'sort_item';
+    }
+
+    #[\Override]
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['name'], 'string'],
+        ];
+    }
+}

--- a/tests/models/SortOwner.php
+++ b/tests/models/SortOwner.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace tests\models;
+
+use p4it\saveRelationsBehavior\SaveRelationsBehavior;
+use yii\db\ActiveRecord;
+
+/**
+ * Owner exercising the per-relation `sortColumn` option, which persists the submitted order of a
+ * via-table (M2M) relation into a junction-table column.
+ *
+ *  - items        : plain M2M, sortColumn only
+ *  - linkedItems  : same junction as items, linkOnly + sortColumn (related records never saved)
+ *  - galleryItems : M2M sharing a junction with docItems, scoped by a `type` discriminator
+ *  - docItems     : the other half of the shared junction (control for discriminator isolation)
+ *  - children     : non-via has-many — sortColumn is unsupported and must be rejected
+ *
+ * The `type` discriminator is encoded both in the relation's `onCondition` (so reads and unlinks
+ * stay scoped to one type) and in the behavior's `extraColumns` (so inserts write the type).
+ */
+class SortOwner extends ActiveRecord
+{
+    #[\Override]
+    public static function tableName()
+    {
+        return 'sort_owner';
+    }
+
+    #[\Override]
+    public function behaviors()
+    {
+        return [
+            'saveRelations' => [
+                'class'     => SaveRelationsBehavior::class,
+                'relations' => [
+                    'items'        => ['sortColumn' => 'sort_order'],
+                    'linkedItems'  => ['linkOnly' => true, 'sortColumn' => 'sort_order'],
+                    'galleryItems' => ['linkOnly' => true, 'extraColumns' => ['type' => 'gallery'], 'sortColumn' => 'sort_order'],
+                    'docItems'     => ['linkOnly' => true, 'extraColumns' => ['type' => 'doc'], 'sortColumn' => 'sort_order'],
+                    'children'     => ['sortColumn' => 'sort_order'],
+                ],
+            ],
+        ];
+    }
+
+    #[\Override]
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['items', 'linkedItems', 'galleryItems', 'docItems', 'children'], 'safe'],
+        ];
+    }
+
+    public function getItems()
+    {
+        return $this->hasMany(SortItem::class, ['id' => 'item_id'])
+            ->viaTable('sort_owner_item', ['owner_id' => 'id']);
+    }
+
+    public function getLinkedItems()
+    {
+        return $this->hasMany(SortItem::class, ['id' => 'item_id'])
+            ->viaTable('sort_owner_item', ['owner_id' => 'id']);
+    }
+
+    public function getGalleryItems()
+    {
+        return $this->hasMany(SortItem::class, ['id' => 'item_id'])
+            ->viaTable('sort_owner_gallery', ['owner_id' => 'id'], fn ($query) => $query->andOnCondition(['type' => 'gallery']));
+    }
+
+    public function getDocItems()
+    {
+        return $this->hasMany(SortItem::class, ['id' => 'item_id'])
+            ->viaTable('sort_owner_gallery', ['owner_id' => 'id'], fn ($query) => $query->andOnCondition(['type' => 'doc']));
+    }
+
+    public function getChildren()
+    {
+        return $this->hasMany(SortChild::class, ['owner_id' => 'id']);
+    }
+}


### PR DESCRIPTION
## What

A new per-relation `sortColumn` option that persists the **submitted order** of a via-table (M2M) relation into a junction-table column, as 0-based positions, on every save.

```php
'saveRelations' => [
    'class'     => SaveRelationsBehavior::class,
    'relations' => [
        'products'     => ['linkOnly' => true, 'sortColumn' => 'sort_order'],
        'galleryFiles' => ['extraColumns' => ['type' => MediaFile::TYPE_GALLERY], 'sortColumn' => 'sort_order'],
    ],
],
```

Off by default; composes with `linkOnly` and `extraColumns`. Replaces hand-rolled per-model `afterSave()` loops that captured relation order before `parent::afterSave()` and re-`updateAll()`'d the junction afterward.

## Why it lives in the behavior

All positions are rewritten on every save, so a **pure reorder** (no membership change) is persisted too — `$owner->link()` alone cannot do this, since it only ever touches *added* rows. The behavior already owns the junction (link/unlink/`extraColumns`), so the ordered write belongs here. The read side stays in the model: the relation getter still defines how records come back ordered (e.g. `ORDER BY sort_order`).

## Design notes

- **Order is snapshotted before `link()`/`unlink()` run.** `BaseActiveRecord::link()` appends added rows to the in-memory populated relation, so reading the relation *after* the sync double-counts them and corrupts positions. The snapshot is taken at the top of `_afterSaveHasManyRelation()`.
- **Scope guard runs in `beforeValidate()`**, alongside the existing `linkOnly` guard, so a non-via misconfiguration throws `InvalidConfigException` before the owner is written (not mid-transaction in `afterSave()`).
- **Junction rows are matched by owner key + related key + `extraColumns`**, via two link loops (not `array_key_first`), so composite-key and discriminator-shared junctions are scoped correctly.
- For a junction shared by relations distinguished by a `type` discriminator, encode that type in the relation's `onCondition` too, so reads/unlinks stay scoped (documented in the README).

## Tests

New `SortColumnTest` (6 cases) asserting the **actual junction `sort_order` values**: insert (`0..N-1`), pure reorder, add+remove+reorder (contiguous renumber), `extraColumns` discriminator isolation, `linkOnly` + `sortColumn`, and non-via → `InvalidConfigException`.

Full suite: **63 tests, 237 assertions** green (was 57). Rector and PHP-CS-Fixer clean.